### PR TITLE
Rename to cargo-wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,8 +43,8 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "cargo-wa"
-version = "0.1.0"
+name = "cargo-wasm"
+version = "0.1.1"
 dependencies = [
  "clap 2.27.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "cargo-wa"
+name = "cargo-wasm"
 version = "0.1.1"
 authors = ["Michael Gattozzi <mgattozzi@gmail.com>"]
 description = "Make developing a wasm project in Rust easy"
-documentation = "https://docs.rs/cargo-wa"
-homepage = "https://github.com/mgattozzi/cargo-wa"
-repository = "https://github.com/mgattozzi/cargo-wa"
+documentation = "https://docs.rs/cargo-wasm"
+homepage = "https://github.com/mgattozzi/cargo-wasm"
+repository = "https://github.com/mgattozzi/cargo-wasm"
 readme = "README.md"
 keywords = ["cargo", "wasm", "web-assembly", "WASM", "subcommand"]
 categories = [

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ installed already.
 ## How to install cargo-wasm
 
 ```bash
-cargo install cargo-wa
+cargo install cargo-wasm
 ```
 
 That's all you need to do! Then you can start running commands!
@@ -22,7 +22,7 @@ That's all you need to do! Then you can start running commands!
 If you have never setup `rustup` for wasm or `wasm-gc` yet at all you need to run:
 
 ```bash
-cargo wa setup
+cargo wasm setup
 ```
 
 This will install `wasm-gc` for you as well as setting up rustup to use the
@@ -33,7 +33,7 @@ This will install `wasm-gc` for you as well as setting up rustup to use the
 To start a new wasm project run:
 
 ```bash
-cargo wa new <project_name>
+cargo wasm new <project_name>
 ```
 
 This will setup a project with a bare wasm skeleton to run wasm function from an
@@ -44,7 +44,7 @@ This will setup a project with a bare wasm skeleton to run wasm function from an
 This command assumes you are at the project root. To build a wasm project run:
 
 ```bash
-cargo wa build
+cargo wasm build
 ```
 
 All builds are currently built/run in release mode due to a wasm bug in debug
@@ -55,7 +55,7 @@ builds. See issue #1.
 This command assumes you are at the project root. To run a wasm project run:
 
 ```bash
-cargo wa run
+cargo wasm run
 ```
 
 This will try to open your default browser and run the code from there.

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ fn run() -> Result<(), Error> {
                          .author(env!("CARGO_PKG_AUTHORS"))
                          .about(env!("CARGO_PKG_DESCRIPTION"))
                          .subcommand(
-                             SubCommand::with_name("wa")
+                             SubCommand::with_name("wasm")
                                         .about("Commiting code and it's options")
                                         .subcommand(
                                             SubCommand::with_name("new")
@@ -58,7 +58,7 @@ fn run() -> Result<(), Error> {
                         )
                          .get_matches();
 
-    if let Some(matches) = matches.subcommand_matches("wa") {
+    if let Some(matches) = matches.subcommand_matches("wasm") {
 
         if let Some(matches) = matches.subcommand_matches("new") {
             cargo_new(matches.value_of("project_name").unwrap())?;


### PR DESCRIPTION
Fixes #2 

This is a rename of the command from cargo-wa -> cargo-wasm.
It also assumes that the github repository will be renamed.

This does not bump the version but presumably it should go to 0.4 (since 0.3 is the latest of the old cargo-wasm crate).