### PR TITLE
README: Link to rust-wasm repo for up-to-date instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A cargo subcommand for working with Rust wasm projects!
 
+See https://github.com/rust-lang-nursery/rust-wasm for the manual steps if cargo-wa doesn't work for you.
+
 ## Build requirements
 
 You'll need the latest stable version of `rustc`, `rustup`, and `cargo`


### PR DESCRIPTION
I came to cargo-wa via googling, but then was disappointed that the instructions in the README didn't actually work (see other pull requests).

rust-wasm seems to be more up-to-date than this, so link there.